### PR TITLE
[Reviewer: Matt] Run expired peers GC thread once a second, not once every two minutes

### DIFF
--- a/libfdcore/p_expiry.c
+++ b/libfdcore/p_expiry.c
@@ -36,7 +36,7 @@
 #include "fdcore-internal.h"
 
 /* Delay for garbage collection of expired peers, in seconds */
-#define GC_TIME		120
+#define GC_TIME		1
 
 static pthread_t       exp_thr = (pthread_t)NULL;
 static pthread_t       gc_thr  = (pthread_t)NULL;


### PR DESCRIPTION
This should fix https://github.com/Metaswitch/cpp-common/issues/106 - as I discuss there, there might be slightly better fixes possible, but I think this change meets our needs and is much faster to code up.
