### PR TITLE
[Reviewer: Andy] Notify Diameter stack when connections are closed cleanly

### DIFF
--- a/libfdcore/p_dp.c
+++ b/libfdcore/p_dp.c
@@ -120,6 +120,7 @@ int fd_p_dp_handle(struct msg ** msg, int req, struct fd_peer * peer)
 			CHECK_FCT( fd_out_send( msg, NULL, peer, 0) );
 			
 			/* and move to CLOSED */
+			fd_hook_call(HOOK_PEER_CONNECT_FAILED, NULL, peer, "Connection closed", NULL);
 			fd_psm_cleanup(peer, 0);
 
 			/* Reset the timer for next connection attempt -- we'll retry sooner or later depending on the disconnection cause */

--- a/libfdcore/p_psm.c
+++ b/libfdcore/p_psm.c
@@ -636,7 +636,10 @@ psm_loop:
 			case CC_DISCONNECT_PEER:
 				CHECK_FCT_DO( fd_p_dp_handle(&msg, (hdr->msg_flags & CMD_FLAG_REQUEST), peer), goto psm_reset );
 				if (fd_peer_getstate(peer) == STATE_CLOSING)
+				{
+					fd_hook_call(HOOK_PEER_CONNECT_FAILED, NULL, peer, "Connection closed", NULL);
 					goto psm_end;
+				}
 
 				break;
 			
@@ -714,9 +717,11 @@ psm_loop:
 				
 			case STATE_CLOSING:
 				/* We sent a DPR so we are terminating, do not wait for DPA */
+				fd_hook_call(HOOK_PEER_CONNECT_FAILED, NULL, peer, "Connection closed", NULL);
 				goto psm_end;
 				
 			case STATE_CLOSING_GRACE:
+				fd_hook_call(HOOK_PEER_CONNECT_FAILED, NULL, peer, "Connection closed", NULL);
 				if (peer->p_flags.pf_localterm) /* initiated here */
 					goto psm_end;
 				
@@ -849,13 +854,19 @@ psm_loop:
 			case STATE_WAITCNXACK:
 			case STATE_WAITCEA:
 				fd_hook_call(HOOK_PEER_CONNECT_FAILED, NULL, peer, "Timeout while waiting for remote peer", NULL);
+				/* Destroy the connection, restart the timer to a new connection attempt */
+				fd_psm_next_timeout(peer, 1, peer->p_hdr.info.config.pic_tctimer ?: fd_g_config->cnf_timer_tc);
+				goto psm_reset;
+
 			case STATE_CLOSING:
+				fd_hook_call(HOOK_PEER_CONNECT_FAILED, NULL, peer, "Connection closed", NULL);
 				/* Destroy the connection, restart the timer to a new connection attempt */
 				fd_psm_next_timeout(peer, 1, peer->p_hdr.info.config.pic_tctimer ?: fd_g_config->cnf_timer_tc);
 				goto psm_reset;
 				
 			case STATE_CLOSING_GRACE:
 				/* The grace period is completed, now close */
+				fd_hook_call(HOOK_PEER_CONNECT_FAILED, NULL, peer, "Connection closed", NULL);
 				if (peer->p_flags.pf_localterm)
 					goto psm_end;
 				


### PR DESCRIPTION
Andy,

Please can you review this fix to https://github.com/Metaswitch/cpp-common/issues/280?  It causes freeDiameter to call the CONNECT_FAILED hook when a connection is closed.  I'm not completely sure it's architecturally right - is a connection being closed a "failure"?  Prior to this change, there was no notification when a connection was closed, so we couldn't tell that we needed to retry/swap.  This change does fix the symptoms but I don't intend to merge this immediately - I'd like to give it a bit more of a kicking but want to check the basic approach with you.

Matt