### PR TITLE
[Reviewer: Matt] Sto1226

### DIFF
--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -72,6 +72,7 @@ FD_EXTENSION_SUBDIR(rt_redirect  "Handling of Diameter Redirect messages" 			ON)
 FD_EXTENSION_SUBDIR(rt_busypeers "Handling of Diameter TOO_BUSY messages and relay timeouts"	ON)
 FD_EXTENSION_SUBDIR(rt_ereg      "Configurable routing based on regexp matching of AVP values" OFF)
 FD_EXTENSION_SUBDIR(rt_ignore_dh "Stow Destination-Host in Proxy-Info, restore to Origin-Host for answers"	ON)
+FD_EXTENSION_SUBDIR(rt_change_dh "Change Destination-Host in Proxy-Info, restore to Origin-Host for answers"      ON)
 FD_EXTENSION_SUBDIR(rt_load_balance "Balance load over multiple equal hosts, based on outstanding requests"	ON)
 
 

--- a/extensions/rt_change_dh/CMakeLists.txt
+++ b/extensions/rt_change_dh/CMakeLists.txt
@@ -1,0 +1,20 @@
+# The rt_change_dh extension
+PROJECT("Routing extension that modifies the Destination-Host on certain requests messages and restores from Proxy-Info for responses" C)
+
+# List of source files
+SET(RT_CHANGE_DH_SRC
+	rt_change_dh.c
+)
+
+INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
+
+# Compile these files as a freeDiameter extension
+FD_ADD_EXTENSION(rt_change_dh ${RT_CHANGE_DH_SRC})
+
+####
+## INSTALL section ##
+
+# We install with the daemon component because it is a base feature.
+INSTALL(TARGETS rt_change_dh
+	LIBRARY DESTINATION ${INSTALL_EXTENSIONS_SUFFIX}
+	COMPONENT freeDiameter-daemon)

--- a/extensions/rt_change_dh/rt_change_dh.c
+++ b/extensions/rt_change_dh/rt_change_dh.c
@@ -151,7 +151,7 @@ static int stow_destination_host(struct msg **msg) {
 			/* add Proxy-Info->{Proxy-Host, Proxy-State} using Destination-Host information */
 			CHECK_FCT(fd_msg_avp_new(ph_avp_do, 0, &ph_avp));
 			memset(&val, 0, sizeof(val));
-                        val.os.data = memdup(fd_g_config->cnf_diamid, fd_g_config->cnf_diamid_len);
+			val.os.data = memdup(fd_g_config->cnf_diamid, fd_g_config->cnf_diamid_len);
 			val.os.len = fd_g_config->cnf_diamid_len;
 			CHECK_FCT(fd_msg_avp_setvalue(ph_avp, &val));
 
@@ -165,8 +165,13 @@ static int stow_destination_host(struct msg **msg) {
 			CHECK_FCT(fd_msg_avp_add(pi_avp, MSG_BRW_LAST_CHILD, ph_avp));
 			CHECK_FCT(fd_msg_avp_add(pi_avp, MSG_BRW_LAST_CHILD, ps_avp));
 
-			/* remove Destination-Host from message */
-			fd_msg_free((msg_or_avp*)avp);
+			/* set the Destination-Host to the local Diameter Identity */
+			union avp_value dh;
+			memset(&dh, 0, sizeof(dh));
+			dh.os.data = memdup(fd_g_config->cnf_diamid, fd_g_config->cnf_diamid_len);
+			dh.os.len = fd_g_config->cnf_diamid_len;
+			CHECK_FCT(fd_msg_avp_setvalue(avp, &dh));
+
 			/* add Proxy-Info */
 			CHECK_FCT(fd_msg_avp_add(*msg, MSG_BRW_LAST_CHILD, pi_avp));
 			fd_log_debug("Stowed Destination-Host '%.*s' into Proxy-Info", (int)val.os.len, (const char *)val.os.data);
@@ -177,30 +182,40 @@ static int stow_destination_host(struct msg **msg) {
 }
 
 /* The callback for putting Destination-Host into Proxy-Info and restoring it on the way back */
-static int rt_ignore_destination_host(void * cbdata, struct msg **msg) {
+static void rt_change_destination_host(enum fd_hook_type type,
+                                       struct msg * msg,
+                                       struct peer_hdr* peer,
+                                       void* other,
+                                       struct fd_hook_permsgdata* pmd,
+                                       void* stack_ptr) {
+	CHECK_PARAMS_DO(&msg && msg, {});
+
+	/* Read the message headers */
 	struct msg_hdr * hdr;
-	int ret;
+	CHECK_FCT_DO(fd_msg_hdr(msg, &hdr), {});
 
-	TRACE_ENTRY("%p %p", cbdata, msg);
+	if ((type == HOOK_MESSAGE_RECEIVED) && (hdr->msg_flags & CMD_FLAG_REQUEST)) {
+		switch (hdr->msg_code) {
+			/* Don't modify CERs/DWRs/DPRs */
+			case CC_CAPABILITIES_EXCHANGE:
+			case CC_DISCONNECT_PEER:
+			case CC_DEVICE_WATCHDOG:
+				break;
 
-	CHECK_PARAMS(msg && *msg);
-
-	/* Read the message header */
-	CHECK_FCT(fd_msg_hdr(*msg, &hdr));
-	if (hdr->msg_flags & CMD_FLAG_REQUEST) {
-		ret = stow_destination_host(msg);
-	} else {
-		ret = restore_origin_host(msg);
+			default:
+				stow_destination_host(&msg);
+		}
 	}
-
-	return ret;
+	else if ((type == HOOK_MESSAGE_PRE_SEND) && (!(hdr->msg_flags & CMD_FLAG_REQUEST))) {
+		restore_origin_host(&msg);
+	}
 }
 
 /* handler */
-static struct fd_rt_fwd_hdl * rt_ignore_destination_host_hdl = NULL;
+static struct fd_hook_hdl *rt_change_dh_hdl = NULL;
 
 /* entry point */
-static int rt_ignore_destination_host_entry(char * conffile)
+static int rt_change_destination_host_entry(char * conffile)
 {
 	CHECK_FCT_DO(fd_dict_search(fd_g_config->cnf_dict, DICT_AVP, AVP_BY_NAME, "Destination-Host", &dh_avp_do, ENOENT),
 		     { TRACE_ERROR("Unable to find 'Destination-Host' AVP in the loaded dictionaries."); });
@@ -214,7 +229,7 @@ static int rt_ignore_destination_host_entry(char * conffile)
 		     { TRACE_ERROR("Unable to find 'Proxy-State' AVP in the loaded dictionaries."); });
 
 	/* Register the callback */
-	CHECK_FCT(fd_rt_fwd_register(rt_ignore_destination_host, NULL, RT_FWD_ALL, &rt_ignore_destination_host_hdl));
+	CHECK_FCT(fd_hook_register(HOOK_MASK(HOOK_MESSAGE_RECEIVED, HOOK_MESSAGE_PRE_SEND), rt_change_destination_host, NULL, NULL, &rt_change_dh_hdl) );
 
 	TRACE_DEBUG(INFO, "Extension 'Ignore Destination Host' initialized");
 	return 0;
@@ -224,8 +239,8 @@ static int rt_ignore_destination_host_entry(char * conffile)
 void fd_ext_fini(void)
 {
 	/* Unregister the callbacks */
-	CHECK_FCT_DO(fd_rt_fwd_unregister(rt_ignore_destination_host_hdl, NULL), /* continue */);
+	CHECK_FCT_DO(fd_hook_unregister(rt_change_dh_hdl), );
 	return ;
 }
 
-EXTENSION_ENTRY("rt_ignore_destination_host", rt_ignore_destination_host_entry);
+EXTENSION_ENTRY("rt_change_destination_host", rt_change_destination_host_entry);

--- a/extensions/rt_change_dh/rt_change_dh.c
+++ b/extensions/rt_change_dh/rt_change_dh.c
@@ -3,6 +3,7 @@
 * Author: Thomas Klausner <tk@giga.or.at>                                                                *
 *                                                                                                        *
 * Copyright (c) 2013, Thomas Klausner                                                                    *
+* Copyright (C) 2015  Metaswitch Networks Ltd
 * All rights reserved.                                                                                   *
 *                                                                                                        *
 * Written under contract by nfotex IT GmbH, http://nfotex.com/                                           *

--- a/include/freeDiameter/libfdcore.h
+++ b/include/freeDiameter/libfdcore.h
@@ -1027,6 +1027,16 @@ enum fd_hook_type {
 		 - {permsgdata} points to a new empty structure allocated for this request (cf. fd_hook_data_hdl)
 		 */
 	
+	HOOK_MESSAGE_PRE_SEND,
+		/* Hook called when a message is about to be sent.
+		 - {msg} points to the message to send. Again, the objects may not have been dictionary resolved. If you
+		   try to call fd_msg_parse_dict, it will slow down the operation of a relay agent.
+                 - {peer} is set if the message is to be sent sent to a peer's connection, and NULL if the message is to be sent to a new client
+                   connected and not yet identified, or being rejected
+                 - {other} is a pointer to a fd_cnx_rcvdata structure describing the received message.
+                 - {permsgdata} points to existing structure if any, or a new structure otherwise.
+                 */
+
 	HOOK_MESSAGE_SENT,
 		/* Hook called when a message has been sent to a peer. The message might be freed as soon as the hook function returns,
 		   so it is not safe to store the pointer for asynchronous processing.

--- a/libfdcore/hooks.c
+++ b/libfdcore/hooks.c
@@ -358,6 +358,12 @@ void   fd_hook_call(enum fd_hook_type type, struct msg * msg, struct fd_peer * p
 				break;
 			}
 			
+			case HOOK_MESSAGE_PRE_SEND: {
+				CHECK_MALLOC_DO(fd_msg_dump_summary(&hook_default_buf, &hook_default_len, NULL, msg, NULL, 0, 1), break);
+				LOG_D("GOING TO SEND TO '%s': %s", peer ? peer->p_hdr.info.pi_diamid : "<unknown>", hook_default_buf);
+				break;
+			}
+
 			case HOOK_MESSAGE_SENT: {
 				CHECK_MALLOC_DO(fd_msg_dump_summary(&hook_default_buf, &hook_default_len, NULL, msg, NULL, 0, 1), break);
 				LOG_D("SENT to '%s': %s", peer ? peer->p_hdr.info.pi_diamid : "<unknown>", hook_default_buf);
@@ -427,7 +433,7 @@ void   fd_hook_call(enum fd_hook_type type, struct msg * msg, struct fd_peer * p
 				}
 				break;
 			}
-			
+		
 			case HOOK_PEER_CONNECT_SUCCESS: {
 				DiamId_t id = NULL;
 				if ((!fd_msg_source_get( msg, &id, NULL )) && (id == NULL)) { /* The CEA is locally issued */

--- a/libfdcore/p_out.c
+++ b/libfdcore/p_out.c
@@ -60,6 +60,8 @@ static int do_send(struct msg ** msg, struct cnxctx * cnx, uint32_t * hbh, struc
 		hdr->msg_hbhid = *hbh;
 		*hbh = hdr->msg_hbhid + 1;
 	}
+
+	fd_hook_call(HOOK_MESSAGE_PRE_SEND, *msg, peer, &msgdata, fd_msg_pmdl_get(*msg));
 	
 	/* Create the message buffer */
 	CHECK_FCT(fd_msg_bufferize( *msg, &buf, &sz ));

--- a/libfdcore/routing_dispatch.c
+++ b/libfdcore/routing_dispatch.c
@@ -715,15 +715,8 @@ static int msg_rt_in(struct msg * msg)
 			return 0;
 		}
 
-		/* If the Destination-Realm is wrong */
-		if (is_dest_realm == NO) {
-			if (fd_g_config->cnf_flags.no_fwd) {
-				fd_hook_call(HOOK_MESSAGE_ROUTING_ERROR, msgptr, NULL, "Message for another realm", fd_msg_pmdl_get(msgptr));
-				CHECK_FCT( return_error( &msgptr, "DIAMETER_UNABLE_TO_DELIVER", "I am not a Diameter agent", NULL) );
-				return 0;
-			}
-		} else if (is_dest_host == YES) {
 		/* If we are listed as Destination-Host */
+		if (is_dest_host == YES) {
 			if (is_local_app == YES) {
 				/* Ok, give the message to the dispatch thread */
 				fd_hook_call(HOOK_MESSAGE_ROUTING_LOCAL, msgptr, NULL, NULL, fd_msg_pmdl_get(msgptr));
@@ -734,10 +727,17 @@ static int msg_rt_in(struct msg * msg)
 				CHECK_FCT( return_error( &msgptr, "DIAMETER_APPLICATION_UNSUPPORTED", NULL, NULL) );
 			}
 			return 0;
-		} else if (is_dest_host == NO) {
-		/* If the message is explicitly for someone else */
+		}
+
+		/* If the message is explicitely for someone else */
+		if ((is_dest_host == NO) || (is_dest_realm == NO)) {
+			char* error = "Message for another realm";
+			if (is_dest_host == NO) {
+				error = "Message for another host";
+			}
+  
 			if (fd_g_config->cnf_flags.no_fwd) {
-				fd_hook_call(HOOK_MESSAGE_ROUTING_ERROR, msgptr, NULL, "Message for another host", fd_msg_pmdl_get(msgptr));
+				fd_hook_call(HOOK_MESSAGE_ROUTING_ERROR, msgptr, NULL, error, fd_msg_pmdl_get(msgptr));
 				CHECK_FCT( return_error( &msgptr, "DIAMETER_UNABLE_TO_DELIVER", "I am not a Diameter agent", NULL) );
 				return 0;
 			}

--- a/libfdcore/routing_dispatch.c
+++ b/libfdcore/routing_dispatch.c
@@ -715,8 +715,15 @@ static int msg_rt_in(struct msg * msg)
 			return 0;
 		}
 
+		/* If the Destination-Realm is wrong */
+		if (is_dest_realm == NO) {
+			if (fd_g_config->cnf_flags.no_fwd) {
+				fd_hook_call(HOOK_MESSAGE_ROUTING_ERROR, msgptr, NULL, "Message for another realm", fd_msg_pmdl_get(msgptr));
+				CHECK_FCT( return_error( &msgptr, "DIAMETER_UNABLE_TO_DELIVER", "I am not a Diameter agent", NULL) );
+				return 0;
+			}
+		} else if (is_dest_host == YES) {
 		/* If we are listed as Destination-Host */
-		if (is_dest_host == YES) {
 			if (is_local_app == YES) {
 				/* Ok, give the message to the dispatch thread */
 				fd_hook_call(HOOK_MESSAGE_ROUTING_LOCAL, msgptr, NULL, NULL, fd_msg_pmdl_get(msgptr));
@@ -727,24 +734,15 @@ static int msg_rt_in(struct msg * msg)
 				CHECK_FCT( return_error( &msgptr, "DIAMETER_APPLICATION_UNSUPPORTED", NULL, NULL) );
 			}
 			return 0;
-		}
-
+		} else if (is_dest_host == NO) {
 		/* If the message is explicitly for someone else */
-		if ((is_dest_host == NO) || (is_dest_realm == NO)) {
 			if (fd_g_config->cnf_flags.no_fwd) {
-				char * error;
-				if (is_dest_host == NO) {
-					error = "Message for another host";
-				}
-				else if (is_dest_realm == NO) {
-					error = "Message for another realm";
-				}
-				fd_hook_call(HOOK_MESSAGE_ROUTING_ERROR, msgptr, NULL, error, fd_msg_pmdl_get(msgptr));
+				fd_hook_call(HOOK_MESSAGE_ROUTING_ERROR, msgptr, NULL, "Message for another host", fd_msg_pmdl_get(msgptr));
 				CHECK_FCT( return_error( &msgptr, "DIAMETER_UNABLE_TO_DELIVER", "I am not a Diameter agent", NULL) );
 				return 0;
 			}
 		} else {
-		/* Destination-Host was not set, and Destination-Realm is matching : we may handle or pass to a fellow peer */
+		/* Destination-Host was not set, and Destination-Realm is matching/unset : we may handle or pass to a fellow peer */
 			int is_nai = 0;
 
 			/* test for decorated NAI  (RFC5729 section 4.4) */

--- a/libfdcore/routing_dispatch.c
+++ b/libfdcore/routing_dispatch.c
@@ -729,10 +729,17 @@ static int msg_rt_in(struct msg * msg)
 			return 0;
 		}
 
-		/* If the message is explicitely for someone else */
+		/* If the message is explicitly for someone else */
 		if ((is_dest_host == NO) || (is_dest_realm == NO)) {
 			if (fd_g_config->cnf_flags.no_fwd) {
-				fd_hook_call(HOOK_MESSAGE_ROUTING_ERROR, msgptr, NULL, "Message for another realm/host", fd_msg_pmdl_get(msgptr));
+				char * error;
+				if (is_dest_host == NO) {
+					error = "Message for another host";
+				}
+				else if (is_dest_realm == NO) {
+					error = "Message for another realm";
+				}
+				fd_hook_call(HOOK_MESSAGE_ROUTING_ERROR, msgptr, NULL, error, fd_msg_pmdl_get(msgptr));
 				CHECK_FCT( return_error( &msgptr, "DIAMETER_UNABLE_TO_DELIVER", "I am not a Diameter agent", NULL) );
 				return 0;
 			}


### PR DESCRIPTION
Matt, can you please review these changes to hook the rt_ignore_dh extension when sending/receiving a message rather than when forwarding to a peer? I've also improved the check for whether the Destination-Realm is valid (previously if the Destination-Host was OK the request was accepted)

Tested with seagull