### PR TITLE
[Reviewer: Matt] Support forcibly closing diameter connections

### DIFF
--- a/include/freeDiameter/libfdcore.h
+++ b/include/freeDiameter/libfdcore.h
@@ -106,6 +106,8 @@ int fd_core_shutdown(void);
 /* Wait for the shutdown to be complete -- this should always be called after fd_core_shutdown */
 int fd_core_wait_shutdown_complete(void);
 
+/* Forcibly shutdown any Diameter connections */
+int fd_connections_shutdown(void);
 
 /*============================================================*/
 /*                          CONFIG                            */

--- a/libfdcore/core.c
+++ b/libfdcore/core.c
@@ -369,6 +369,9 @@ int fd_core_wait_shutdown_complete(void)
 	return 0;
 }
 
-
-
-
+/* Forcibly shut down any Diameter connections */
+int fd_connections_shutdown(void)
+{
+        LOG_N( FD_PROJECT_BINARY " Closing Diameter connections");
+        CHECK_FCT_DO( fd_peer_fini_force(), /* Stop all connections */ );
+}

--- a/libfdcore/fdcore-internal.h
+++ b/libfdcore/fdcore-internal.h
@@ -286,6 +286,7 @@ void fd_peer_failover_msg(struct fd_peer * peer);
 /* Peer expiry */
 int fd_p_expi_init(void);
 int fd_p_expi_fini(void);
+int fd_p_expi_fini_force(void);
 int fd_p_expi_update(struct fd_peer * peer );
 
 /* Peer state machine */

--- a/libfdcore/peers.c
+++ b/libfdcore/peers.c
@@ -396,7 +396,7 @@ int fd_peer_free(struct fd_peer ** ptr)
 	CHECK_FCT_DO( fd_fifo_del(&p->p_tosend), /* continue */ );
 	CHECK_FCT_DO( fd_fifo_del(&p->p_tofailover), /* continue */ );
 	CHECK_POSIX_DO( pthread_mutex_destroy(&p->p_state_mtx), /* continue */);
-	CHECK_POSIX_DO( pthread_mutex_destroy(&p->p_sr.mtx), /* continue */);
+ 	CHECK_POSIX_DO( pthread_mutex_destroy(&p->p_sr.mtx), /* continue */);
 	CHECK_POSIX_DO( pthread_cond_destroy(&p->p_sr.cnd), /* continue */);
 	
 	/* If the callback is still around... */
@@ -464,36 +464,50 @@ int fd_peer_fini()
 		CHECK_FCT_DO( pthread_rwlock_unlock(&fd_g_peers_rw), /* continue */ );
 		CHECK_SYS(  clock_gettime(CLOCK_REALTIME, &now)  );
 	}
-	
-	if (!list_empty) {
-		TRACE_DEBUG(INFO, "Forcing connections shutdown");
-		CHECK_FCT_DO( pthread_rwlock_wrlock(&fd_g_peers_rw), /* continue */ );
-		while (!FD_IS_LIST_EMPTY(&fd_g_peers)) {
-			struct fd_peer * peer = (struct fd_peer *)(fd_g_peers.next->o);
-			fd_psm_abord(peer);
-			fd_list_unlink(&peer->p_hdr.chain);
-			fd_list_insert_before(&purge, &peer->p_hdr.chain);
-		}
-		CHECK_FCT_DO( pthread_rwlock_unlock(&fd_g_peers_rw), /* continue */ );
-	}
-	
-	/* Free memory objects of all peers */
-	while (!FD_IS_LIST_EMPTY(&purge)) {
-		struct fd_peer * peer = (struct fd_peer *)(purge.next->o);
-		fd_list_unlink(&peer->p_hdr.chain);
-		fd_peer_free(&peer);
-	}
-	
-	/* Now empty the validators list */
-	CHECK_FCT_DO( pthread_rwlock_wrlock(&validators_rw), /* continue */ );
-	while (!FD_IS_LIST_EMPTY( &validators )) {
-		struct fd_list * v = validators.next;
-		fd_list_unlink(v);
-		free(v);
-	}
-	CHECK_FCT_DO( pthread_rwlock_unlock(&validators_rw), /* continue */ );
+
+        fd_peer_fini_force();
+
+        /* Now empty the validators list */
+        CHECK_FCT_DO( pthread_rwlock_wrlock(&validators_rw), /* continue */ );
+        while (!FD_IS_LIST_EMPTY( &validators )) {
+                struct fd_list * v = validators.next;
+                fd_list_unlink(v);
+                free(v);
+        }
+        CHECK_FCT_DO( pthread_rwlock_unlock(&validators_rw), /* continue */ );
 	
 	return 0;
+}
+
+/* Terminate peer module (destroy all peers forcibly) */
+int fd_peer_fini_force()
+{
+        struct fd_list * li;
+        struct fd_list purge = FD_LIST_INITIALIZER(purge); /* Store zombie peers here */
+        int list_empty;
+
+        CHECK_FCT_DO( pthread_rwlock_wrlock(&fd_g_peers_rw), /* continue */ );
+        list_empty = FD_IS_LIST_EMPTY(&fd_g_peers);
+        CHECK_FCT_DO( pthread_rwlock_unlock(&fd_g_peers_rw), /* continue */ );
+
+        if (!list_empty) {
+                TRACE_DEBUG(INFO, "Forcing connections shutdown");
+                CHECK_FCT_DO( pthread_rwlock_wrlock(&fd_g_peers_rw), /* continue */ );
+                while (!FD_IS_LIST_EMPTY(&fd_g_peers)) {
+                        struct fd_peer * peer = (struct fd_peer *)(fd_g_peers.next->o);
+                        fd_psm_abord(peer);
+                        fd_list_unlink(&peer->p_hdr.chain);
+                        fd_list_insert_before(&purge, &peer->p_hdr.chain);
+                }
+                CHECK_FCT_DO( pthread_rwlock_unlock(&fd_g_peers_rw), /* continue */ );
+        }
+
+        /* Free memory objects of all peers */
+        while (!FD_IS_LIST_EMPTY(&purge)) {
+                struct fd_peer * peer = (struct fd_peer *)(purge.next->o);
+                fd_list_unlink(&peer->p_hdr.chain);
+                fd_peer_free(&peer);
+        }
 }
 
 /* Dump info of one peer */


### PR DESCRIPTION
Matt, can you please review this change to split out the function to forcibly close Diameter connections (so that it can be called by itself in the Diameter stack)

Tested live