### PR TITLE
Reviewer EM: Free peers after aggressively disconnecting them

### DIFF
--- a/libfdcore/fdcore-internal.h
+++ b/libfdcore/fdcore-internal.h
@@ -286,7 +286,6 @@ void fd_peer_failover_msg(struct fd_peer * peer);
 /* Peer expiry */
 int fd_p_expi_init(void);
 int fd_p_expi_fini(void);
-int fd_p_expi_fini_force(void);
 int fd_p_expi_update(struct fd_peer * peer );
 
 /* Peer state machine */

--- a/libfdcore/peers.c
+++ b/libfdcore/peers.c
@@ -508,6 +508,13 @@ int fd_peer_fini_force()
                 }
                 CHECK_FCT_DO( pthread_rwlock_unlock(&fd_g_peers_rw), /* continue */ );
         }
+
+        /* Free memory objects of all peers */
+        while (!FD_IS_LIST_EMPTY(&purge)) {
+                struct fd_peer * peer = (struct fd_peer *)(purge.next->o);
+                fd_list_unlink(&peer->p_hdr.chain);
+                fd_peer_free(&peer);
+        }
 }
 
 /* Dump info of one peer */


### PR DESCRIPTION
Ellie,

This is the fix we discussed. fd_peer_free removes the peer from the expiry list (which I think was causing the problems).

I've also removed a function definition which didn't seem to correspond to an actual function.

I'm in the process of testing this by installing the new code on the staging system, stopping cassandra (and checking all of the peer connections are dropped), restarting cassandra (and checking all the peers reconnect as appropriate) and then running overnight and checking the diameter stack never shuts down. I've done all but the last part of this successfully.

@bossmc may also like to comment.

Thanks!