### PR TITLE
Reviewer RKD: Fix cpp-common issue 106

### DIFF
--- a/include/freeDiameter/libfdcore.h
+++ b/include/freeDiameter/libfdcore.h
@@ -339,7 +339,11 @@ struct peer_hdr {
 
 /* the global list of peers. 
   Since we are not expecting so many connections, we don't use a hash, but it might be changed.
-  The list items are peer_hdr structures (actually, fd_peer, but the cast is OK) */
+  The list items are peer_hdr structures (actually, fd_peer, but the cast is OK).
+
+  There can by multiple peers with the same Diameter-Id on this list, but at most one of these
+  peers can be non-zombie peers (i.e. if there are multiple peers with the same Diameter-Id,
+  all but one of them (or all of them) should be in STATE_ZOMBIE). */
 extern struct fd_list fd_g_peers;
 extern pthread_rwlock_t fd_g_peers_rw; /* protect the list */
 
@@ -402,7 +406,10 @@ int fd_peer_remove ( DiamId_t diamid, size_t diamidlen );
  *  peer	: The peer is stored here if it exists.
  *
  * DESCRIPTION: 
- *   Search a peer by its Diameter-Id.
+ *   Search for a peer in fd_g_peers by its Diameter-Id. If there are multiple
+ *   such peers, prefer a non-zombie peer. There should be at most one
+ *   non-zombie peer. All zombie peers (with the given Diameter-Id) are treated
+ *   equally.
  *
  * RETURN VALUE:
  *  0   : *peer has been updated (to NULL if the peer is not found).

--- a/libfdcore/peers.c
+++ b/libfdcore/peers.c
@@ -154,9 +154,17 @@ int fd_peer_add ( struct peer_info * info, const char * orig_dbg, void (*cb)(str
 			li_inf = li; /* it will come after this element, for sure */
 		
 		if (cmp == 0) {
-			ret = EEXIST; /* we have a duplicate */
-			break;
+			if (fd_peer_getstate(li) == STATE_ZOMBIE) {
+				/* If the existing peer is in zombie state then we can add it again, so
+				 * continue as if we hadn't found it */
+				li_inf = li;
+			}
+			else {
+				ret = EEXIST; /* we have a duplicate */
+				break;
+			}
 		}
+
 		if (!cont)
 			break;
 	}
@@ -175,7 +183,13 @@ int fd_peer_add ( struct peer_info * info, const char * orig_dbg, void (*cb)(str
 	if (ret) {
 		CHECK_FCT( fd_peer_free(&p) );
 	} else {
-		TRACE_DEBUG(FULL, "Diameter peer %*s added", (int)info->pi_diamidlen, info->pi_diamid);
+		char* peers_str = NULL;
+		size_t peers_str_len;
+		fd_peer_dump_list(&peers_str, &peers_str_len, NULL, 0);
+		TRACE_DEBUG(FULL, "Diameter peer %.*s added", (int)info->pi_diamidlen, info->pi_diamid);
+		TRACE_DEBUG(FULL, "New global list of peers:\n%.*s", (int)peers_str_len, peers_str);
+		free(peers_str); peers_str = NULL;
+
 		CHECK_FCT( fd_psm_begin(p) );
 	}
 	return ret;
@@ -185,7 +199,7 @@ int fd_peer_add ( struct peer_info * info, const char * orig_dbg, void (*cb)(str
 int fd_peer_remove ( DiamId_t diamid, size_t diamidlen )
 {
 	struct fd_list * li;
-	TRACE_DEBUG(FULL, "Remove diameter peer %*s", (int)diamidlen, diamid);
+	TRACE_DEBUG(FULL, "Remove diameter peer %.*s", (int)diamidlen, diamid);
 	int found = 0;
 
 	// Find the peer in the peer list from its pi_diamid.
@@ -194,7 +208,7 @@ int fd_peer_remove ( DiamId_t diamid, size_t diamidlen )
 		struct fd_peer * peer = (struct fd_peer *)li;
 		int cmp = fd_os_cmp( diamid, diamidlen, peer->p_hdr.info.pi_diamid, peer->p_hdr.info.pi_diamidlen );
 
-		if (cmp == 0) {
+		if ((cmp == 0) && (fd_peer_getstate(peer) != STATE_ZOMBIE)) {
 			/* update the peer lifetime, set the expiry flag and call fd_p_expi_update so that the
 			 * p_exp_timer value is updated and the peer expires immediately. */
 			peer->p_hdr.info.config.pic_flags.exp = PI_EXP_INACTIVE;
@@ -223,6 +237,7 @@ int fd_peer_getbyid( DiamId_t diamid, size_t diamidlen, int igncase, struct peer
 	CHECK_PARAMS( diamid && diamidlen && peer );
 	
 	*peer = NULL;
+	struct peer_hdr* zombie_peer = NULL;
 	
 	/* Search in the list */
 	CHECK_POSIX( pthread_rwlock_rdlock(&fd_g_peers_rw) );
@@ -232,8 +247,13 @@ int fd_peer_getbyid( DiamId_t diamid, size_t diamidlen, int igncase, struct peer
 			int cmp, cont;
 			cmp = fd_os_almostcasesrch( diamid, diamidlen, next->p_hdr.info.pi_diamid, next->p_hdr.info.pi_diamidlen, &cont );
 			if (cmp == 0) {
-				*peer = &next->p_hdr;
-				break;
+				if (fd_peer_getstate(next) != STATE_ZOMBIE) {
+					*peer = &next->p_hdr;
+					break;
+				}
+				else if (zombie_peer == NULL) {
+					zombie_peer = &next->p_hdr;
+				}
 			}
 			if (!cont)
 				break;
@@ -244,12 +264,23 @@ int fd_peer_getbyid( DiamId_t diamid, size_t diamidlen, int igncase, struct peer
 			int cmp = fd_os_cmp( diamid, diamidlen, next->p_hdr.info.pi_diamid, next->p_hdr.info.pi_diamidlen );
 			if (cmp > 0)
 				continue;
-			if (cmp == 0)
-				*peer = &next->p_hdr;
-			break;
+			if (cmp == 0) {
+				if (fd_peer_getstate(next) != STATE_ZOMBIE) {
+					*peer = &next->p_hdr;
+					break;
+				}
+				else if (zombie_peer == NULL) {
+					zombie_peer = &next->p_hdr;
+				}
+			}
 		}
 	}
 	CHECK_POSIX( pthread_rwlock_unlock(&fd_g_peers_rw) );
+
+	if ((peer == NULL) && (zombie_peer != NULL))
+	{
+		*peer = zombie_peer;
+	}
 	
 	return 0;
 }
@@ -646,8 +677,15 @@ int fd_peer_handle_newCER( struct msg ** cer, struct cnxctx ** cnx )
 			li_inf = li;
 		}
 		if (cmp == 0) {
-			found = 1;
-			break;
+			if (fd_peer_getstate(li) == STATE_ZOMBIE) {
+				/* If the existing peer is in zombie state then we can add it again, so
+				 * continue as if we hadn't found it */
+				li_inf = li;
+			}
+			else {
+				found = 1;
+				break;
+			}
 		}
 		if (!cont)
 			break;
@@ -682,18 +720,6 @@ int fd_peer_handle_newCER( struct msg ** cer, struct cnxctx ** cnx )
 		
 		/* Start the PSM, which will receive the event below */
 		CHECK_FCT_DO( ret = fd_psm_begin(peer), goto out );
-	} else {
-		/* Check if the peer is in zombie state */
-		if (fd_peer_getstate(peer) == STATE_ZOMBIE) {
-			/* Re-activate the peer */
-			if (peer->p_hdr.info.config.pic_flags.exp)
-				peer->p_flags.pf_responder = 1;
-			CHECK_POSIX_DO( pthread_mutex_lock(&peer->p_state_mtx), );
-			peer->p_state = STATE_NEW;
-			CHECK_POSIX_DO( pthread_mutex_unlock(&peer->p_state_mtx), );
-			peer->p_flags.pf_localterm = 0;
-			CHECK_FCT_DO( ret = fd_psm_begin(peer), goto out );
-		}
 	}
 	
 	/* Send the new connection event to the PSM */

--- a/libfdcore/peers.c
+++ b/libfdcore/peers.c
@@ -158,8 +158,7 @@ int fd_peer_add ( struct peer_info * info, const char * orig_dbg, void (*cb)(str
 				/* If the existing peer is in zombie state then we can add it again, so
 				 * continue as if we hadn't found it */
 				li_inf = li;
-			}
-			else {
+			} else {
 				ret = EEXIST; /* we have a duplicate */
 				break;
 			}


### PR DESCRIPTION
Hi Rob,

Please can you review my fix for https://github.com/Metaswitch/cpp-common/issues/106? The design is as discussed, so hopefully this shouldn't be too controversial, and I think you'll be extremely impressed with my indentation; freeDiameter is notoriously a tricky project to get indentation right in, so I'm particularly proud of my efforts.

At a high level I'm testing the following things.
- [x] Ralf can immediately reconnect to CDFs (either if the connection has been lost or deliberately torn down) - i.e. the issue is fixed
- [x] The Rf interface still works with traffic going through it
- [x] Homestead still works, either with hss_hostname or hss_realm configured
- [x] Our Diameter stack still works for clients, particularly if the server has recently been restarted and is therefore a zombie

Any questions, let me know.

Thanks,
Graeme