### PR TITLE
Reviewer MIRW: Abort on error

### DIFF
--- a/libfdcore/p_expiry.c
+++ b/libfdcore/p_expiry.c
@@ -138,7 +138,6 @@ static void * exp_th_fct(void * arg)
 	pthread_cleanup_pop( 1 );
 
 	TRACE_DEBUG(INFO, "An error occurred in peers module! Terminating process...");
-	CHECK_FCT_DO(fd_core_shutdown(), );
 	abort();
 	return NULL;
 }

--- a/libfdcore/p_expiry.c
+++ b/libfdcore/p_expiry.c
@@ -137,8 +137,9 @@ static void * exp_th_fct(void * arg)
 	
 	pthread_cleanup_pop( 1 );
 
-	TRACE_DEBUG(INFO, "An error occurred in peers module! Expiry thread is terminating...");
+	TRACE_DEBUG(INFO, "An error occurred in peers module! Terminating process...");
 	CHECK_FCT_DO(fd_core_shutdown(), );
+	abort();
 	return NULL;
 }
 

--- a/libfdcore/p_expiry.c
+++ b/libfdcore/p_expiry.c
@@ -131,7 +131,15 @@ static void * exp_th_fct(void * arg)
 		
 		/* Now, the first peer in the list is expired; signal it */
 		fd_list_unlink( &first->p_expiry );
-		CHECK_FCT_DO( fd_event_send(first->p_events, FDEVP_TERMINATE, 0, "DO_NOT_WANT_TO_TALK_TO_YOU"), break );
+
+		/* Previously if we failed this check, we would break (and abort the
+		 * process, below). However, we don't really want to ever do that - we think
+		 * we've failed this check due to a race condition
+		 * (https://github.com/Metaswitch/homestead/issues/399) when it wasn't
+		 * actually necessary to abort the program. If we are left with a broken
+		 * Diameter connection we'll catch that in our DiameterStack and restart the
+		 * process anyway. See the discussion on that issue for more info. */
+		CHECK_FCT_DO( fd_event_send(first->p_events, FDEVP_TERMINATE, 0, "DO_NOT_WANT_TO_TALK_TO_YOU"), /* break */ );
 		
 	} while (1);
 	


### PR DESCRIPTION
See https://github.com/Metaswitch/homestead/issues/399, particularly my final comment.

I can't work out what is causing the underlying issue, but leaving the process running once we've hit the error is the big problem here, so this is enough to reduce the priority of the issue.

(https://github.com/Metaswitch/homestead/issues/406 is a duplicate I believe)