### PR TITLE
[Reviewer: Ellie] Changed a debug log to an error log

### DIFF
--- a/libfdcore/cnxctx.c
+++ b/libfdcore/cnxctx.c
@@ -298,7 +298,7 @@ struct cnxctx * fd_cnx_cli_connect_tcp(sSA * sa /* contains the port already */,
 	{
 		int ret = fd_tcp_client( &sock, sa, addrlen );
 		if (ret != 0) {
-			LOG_D("TCP connection to %s failed: %s", sa_buf, strerror(ret));
+			LOG_E("TCP connection to %s failed: %s", sa_buf, strerror(ret));
 			return NULL;
 		}
 	}


### PR DESCRIPTION
Changed a debug log to an error log in free diameter, such that it is displayed in the logs why a connection failure has occurred.

Tested that this resulted in an error message, with a reason for the connection failure, in the logs when Homestead failed to connect to the HSS. 