### PR TITLE
[Reviewer: Richard] Set TCP_NODELAY to be on for our TCP connections

### DIFF
--- a/libfdcore/tcp.c
+++ b/libfdcore/tcp.c
@@ -49,6 +49,12 @@ static int fd_tcp_setsockopt(int family, int sk)
 	/* Set TCP_NODELAY, as we anticipate that there may be latency on our diameter
 	   connections, and we don't want to delay sending a TCP packet while waiting
 	   for an ACK that may take a long time (tens or hundreds of ms) to arrive.
+
+	   Note that RFC 3539 section 3.2 says that Nagle's algoritm should be used,
+	   (i.e. TCP_NODELAY should be off) to avoid sending lots of small packets.
+	   However, we've decided to turn TCP_NODELAY on as we can't afford the
+	   latency hit that using it gives us if we don't get Diameter responses fast
+	   enough.
 	*/
 	opt = 1;
 	ret = setsockopt(sk, IPPROTO_TCP, TCP_NODELAY, &opt, sizeof(opt));

--- a/libfdcore/tcp.c
+++ b/libfdcore/tcp.c
@@ -45,10 +45,12 @@ static int fd_tcp_setsockopt(int family, int sk)
 {
 	int ret = 0;
 	int opt;
-	
-	/* Clear the NODELAY option in case it was set, as requested by rfc3539#section-3.2 */
-	/* Note that this is supposed to be the default, so we could probably remove this call ... */
-	opt = 0;
+
+	/* Set TCP_NODELAY, as we anticipate that there may be latency on our diameter
+	   connections, and we don't want to delay sending a TCP packet while waiting
+	   for an ACK that may take a long time (tens or hundreds of ms) to arrive.
+	*/
+	opt = 1;
 	ret = setsockopt(sk, IPPROTO_TCP, TCP_NODELAY, &opt, sizeof(opt));
 	if (ret != 0) {
 		ret = errno;


### PR DESCRIPTION
This is a fix for https://github.com/Metaswitch/clearwater-issues/issues/2632

In that issue, when we forced latency on Homestead's connection to the HSS, we saw that sometimes Homestead's outbound TCP messages were delayed until we received the TCP ACK (which normally comes on the diameter response) from the HSS. This manifested as Homestead thinking it sent the packet at one time in SAS, but the packet capture showing that it was actually sent later (I saw 140ms additional delay for a concrete number).

We saw timeouts because of this (and because of actual delays on the HSS).

Because we expect it's likely that an HSS will take time to respond, and because we use a single TCP connection for each diameter peer, I think we should be enabling TCP_NODELAY (which effectively disables Nagle's algorithm) on these connections, to improve latency.

The downside to doing this is that you may increase bandwidth requirements, if you end up writing partial messages to a socket buffer (which would send each partial message as its own TCP packet). However, I've tested this and haven't seen any more partial diameter messages being sent by Homestead with this option turned on (which I think is because freeDiameter is writing whole diameter messages), so I think this is fine.

With this fix, I re-ran load and still saw a few timeouts, but digging into the packet capture and SAS trace, I can see that Homestead was actually sending out the packet at the time it claimed to in SAS, so I'm quite confident this has reduced the delay on outbound diameter from Homestead.